### PR TITLE
Typos

### DIFF
--- a/_carew/posts/2015-06-10-sf-differently-part-2-bootstrap.md
+++ b/_carew/posts/2015-06-10-sf-differently-part-2-bootstrap.md
@@ -241,7 +241,7 @@ class RollbackKernel implements HttpKernelInterface
 }
 ```
 
-To be able to use `RollabKernel` in our test we need to make it available by
+To be able to use `RollbackKernel` in our tests we need to make it available by
 creating the following `app/bootstrap_test.php`:
 
 ```php


### PR DESCRIPTION
Maybe it's overkill, but you can change `php app/console ...` by `/usr/bin/env php app/console` in `bin/*.sh`