### PR TITLE
Add missing method calls in the unit test

### DIFF
--- a/_sculpin/source/_posts/2016-05-11-towards-cqrs-command-bus.md
+++ b/_sculpin/source/_posts/2016-05-11-towards-cqrs-command-bus.md
@@ -296,8 +296,8 @@ class CreateNewProfileHandlerTest extends \PHPUnit_Framework_TestCase
         $this->saveNewProfile = $this->prophesize(SaveNewProfile::class);
 
         $this->createNewProfileHandler = new CreateNewProfileHandler(
-            $this->checkProfileNameDuplicates,
-            $this->saveNewProfile
+            $this->checkProfileNameDuplicates->reveal(),
+            $this->saveNewProfile->reveal()
         );
     }
 


### PR DESCRIPTION
The prophecies should be `reveal()`ed when injecting them to the SUT.