### PR TITLE
fixed an error in Super Speed Symfony article

### DIFF
--- a/2016/04/13/super-speed-sf-react-php.html
+++ b/2016/04/13/super-speed-sf-react-php.html
@@ -308,7 +308,7 @@ $callback = function ($request, $response) use ($kernel) {
         $sfResponse-&gt;headers-&gt;all()
     );
     $response-&gt;end($sfResponse-&gt;getContent());
-    $kernel-&gt;terminate($request, $response);
+    $kernel-&gt;terminate($sfRequest, $sfResponse);
     if ($enableProfiling) {
         $blackfire-&gt;endProbe($probe);
     }


### PR DESCRIPTION
The Request and Response objects passed to terminate must be from Symfony, not React otherwise results in the following error: 

```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Symfony\Component\HttpKernel\Kernel::terminate() must be an instance of Symfony\Component\HttpFoundation\Request, instance of React\Http\Request given, called in /hack/dev/stuv-api/bin/react.php on line 41 in /hack/dev/stuv-api/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:130
Stack trace:
#0 /hack/dev/stuv-api/bin/react.php(41): Symfony\Component\HttpKernel\Kernel->terminate(Object(React\Http\Request), Object(Symfony\Component\HttpFoundation\Response))
#1 [internal function]: {closure}(Object(React\Http\Request), Object(React\Http\Response))
#2 /hack/dev/stuv-api/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(64): call_user_func_array(Object(Closure), Array)
#3 /hack/dev/stuv-api/vendor/react/http/src/Server.php(63): Evenement\EventEmitter->emit('request', Array)
#4 /hack/dev/stuv-api/vendor/react/http/src/Server.php(27): React\Http\Server->handleRequest(Object(React\Socket\Co in /hack/dev/stuv-api/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php on line 94
```